### PR TITLE
fix(cuda): Corrige chave de fechamento ausente em ssm_kernel_conv

### DIFF
--- a/cuda/ssm_kernel_conv.cu
+++ b/cuda/ssm_kernel_conv.cu
@@ -18,3 +18,4 @@ void ssm_kernel_conv(
     }
 
     output[b * (L - K + 1) + t] = acc;
+}


### PR DESCRIPTION
### Descrição

Este PR corrige um erro de sintaxe crítico no kernel CUDA `ssm_kernel_conv.cu` que impedia a compilação do projeto.

### Problema

O compilador `nvcc` reportava o erro `At end of source: error: expected a "}"` porque a função `ssm_kernel_conv` não possuía a chave de fechamento `}`.

### Solução

A chave de fechamento `}` foi adicionada ao final da definição da função, restaurando a sintaxe correta do C++/CUDA e permitindo que o script de build (`build.rs`) compile o kernel com sucesso.

**Como testar:**
1. Puxe este branch.
2. Execute `cargo clean`.
3. Execute `cargo build` ou `cargo run`.
4. O projeto deve compilar sem erros relacionados ao `ssm_kernel_conv.cu`.